### PR TITLE
Disallow "$" in label names

### DIFF
--- a/src/main/scala/com/github/tarao/record4s/Record.scala
+++ b/src/main/scala/com/github/tarao/record4s/Record.scala
@@ -196,7 +196,8 @@ object Record {
 abstract class % extends Record with Selectable {
   private[record4s] def __data: Map[String, Any]
 
-  def selectDynamic(name: String): Any = __data(name)
+  def selectDynamic(name: String): Any =
+    __data(scala.reflect.NameTransformer.decode(name))
 
   override def toString(): String =
     __data.iterator.map { case (k, v) => s"$k = $v" }.mkString("%(", ", ", ")")

--- a/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
+++ b/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
@@ -62,6 +62,17 @@ class RecordSpec extends helper.UnitSpec {
         """%("age" -> 3, label -> "tarao")""" shouldNot compile
       }
 
+      it("should not allow '$' in labels") {
+        "%($value = 3)" shouldNot compile
+        "%(value$ = 3)" shouldNot compile
+        "%($minusfoobar = 3)" shouldNot compile
+        "%(foo$minusbar = 3)" shouldNot compile
+        "%(foobar$minus = 3)" shouldNot compile
+
+        case class Cell($value: Int)
+        "Record.from(Cell(3))" shouldNot compile
+      }
+
       it("should reject non-vararg construction") {
         val args = Seq("name" -> "tarao")
         "%(args: _*)" shouldNot compile

--- a/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
+++ b/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
@@ -73,6 +73,11 @@ class RecordSpec extends helper.UnitSpec {
         "Record.from(Cell(3))" shouldNot compile
       }
 
+      it("should allow other signs in labels") {
+        val r = %(`foo-bar` = 3)
+        r.`foo-bar` shouldBe 3
+      }
+
       it("should reject non-vararg construction") {
         val args = Seq("name" -> "tarao")
         "%(args: _*)" shouldNot compile


### PR DESCRIPTION
We can't allow `$` because                                               
- (1) Scala compiler passes encoded name to `selectDynamic`, and         
- (2) `$` itself never gets encoded i.e. we can't distinguish for example between `$minus-` and `--` (both are encoded to `$minus$minus`). 

See discussion in scala-records:
- https://github.com/scala-records/scala-records/issues/110
- https://github.com/scala-records/scala-records/issues/121