### PR TITLE
Less transparent record concatenation

### DIFF
--- a/src/main/scala/com/github/tarao/record4s/Macros.scala
+++ b/src/main/scala/com/github/tarao/record4s/Macros.scala
@@ -14,7 +14,7 @@ object Macros {
 
     label.asTerm match {
       case Inlined(_, _, Literal(StringConstant(label))) =>
-        val schema = schemaOf[R]
+        val schema = schemaOfRecord[R]
         val valueType =
           schema.fieldTypes.find(_._1 == label).map(_._2).getOrElse {
             report
@@ -67,43 +67,6 @@ object Macros {
     }
   }
 
-  /** Macro implementation of `%.++` */
-  def concatImpl[R1: Type, R2: Type](
-    record: Expr[R1],
-    other: Expr[R2],
-  )(using Quotes): Expr[Any] = {
-    import quotes.reflect.*
-    val internal = summon[InternalMacros]
-    import internal.*
-
-    // `tidiedIterableOf` needed here otherwise hidden fields in an upcasted `other` may
-    // break the field in `record`.
-    //
-    // Example:
-    //   val record = %(name = "tarao", email = "tarao@example.com")
-    //   val other: %{val age: Int} = %(age = 3, email = %(user = "ikura", domain = "example.com"))
-    //   record ++ other
-    //   // should be  %(name = tarao, age = 3, email = tarao@example.com)
-    //   // instead of %(name = tarao, age = 3, email = %(user = ikura, domain = example.com))
-    val (rec1, schema1) = iterableOf(record)
-    val (rec2, schema2) = tidiedIterableOf(other)
-
-    val newSchema = (schema1 ++ schema2).deduped._1.asType
-    extend(rec1, rec2)(newSchema)
-  }
-
-  /** Macro implementation of `%.as` */
-  def upcastImpl[R1 <: `%`: Type, R2 >: R1: Type](
-    record: Expr[R1],
-  )(using Quotes): Expr[R2] = {
-    import quotes.reflect.*
-    val internal = summon[InternalMacros]
-    import internal.*
-
-    val (tidied, _) = tidiedIterableOf('{ ${ record }: R2 })
-    newMapRecord[R2](tidied)
-  }
-
   /** Macro implementation of `%.to` */
   def toProductImpl[R <: `%`: Type, P <: Product: Type](
     record: Expr[R],
@@ -112,7 +75,7 @@ object Macros {
     val internal = summon[InternalMacros]
     import internal.*
 
-    val schema = schemaOf[R].fieldTypes.toMap
+    val schema = schemaOfRecord[R].fieldTypes.toMap
     val fieldTypes = schemaOf(evidenceOf[RecordLike[P]]).fieldTypes
 
     // type check
@@ -146,6 +109,58 @@ object Macros {
       .select(method)
       .appliedToArgs(args.toList)
       .asExprOf[P]
+  }
+
+  def derivedRecordLikeImpl[R <: `%`: Type](using
+    Quotes,
+  ): Expr[RecordLike[R]] = {
+    import quotes.reflect.*
+    val internal = summon[InternalMacros]
+    import internal.*
+
+    val schema = schemaOfRecord[R]
+    val elemLabels = schema
+      .fieldTypes
+      .foldRight(Type.of[EmptyTuple]: Type[_]) { case ((label, _), base) =>
+        (base, ConstantType(StringConstant(label)).asType) match {
+          case ('[EmptyTuple], '[label])   => Type.of[label *: EmptyTuple]
+          case ('[head *: tail], '[label]) => Type.of[label *: head *: tail]
+        }
+      }
+
+    elemLabels match {
+      case '[elemLabels] =>
+        '{
+          (new Record.RecordLikeRecord[R]).asInstanceOf[
+            RecordLike[R] {
+              type FieldTypes = R
+              type ElemLabels = elemLabels
+            },
+          ]
+        }
+    }
+  }
+
+  def derivedTypingConcatImpl[R1: Type, R2: Type](using
+    Quotes,
+  ): Expr[Typing.Concat[R1, R2]] = {
+    import quotes.reflect.*
+    val internal = summon[InternalMacros]
+    import internal.*
+
+    val schema1 = schemaOf[R1]
+    val schema2 = schemaOf[R2]
+
+    (schema1 ++ schema2).deduped._1.asType match {
+      case '[tpe] =>
+        '{
+          (new Typing.Concat).asInstanceOf[
+            Typing.Concat[R1, R2] {
+              type Out = tpe
+            },
+          ]
+        }
+    }
   }
 
   private def typeReprOf(

--- a/src/main/scala/com/github/tarao/record4s/Record.scala
+++ b/src/main/scala/com/github/tarao/record4s/Record.scala
@@ -103,28 +103,6 @@ object Record {
     transparent inline def ++[R2](other: R2)(using RecordLike[R2]) =
       ${ Macros.concatImpl('record, 'other) }
 
-    /** Concatenate this record and another record.
-      *
-      * A field of the same name in the both record is statically rejected.
-      *
-      * @example
-      *   {{{
-      * val r1 = %(name = "tarao", age = 3)
-      * val r2 = %(email = "tarao@example.com")
-      * val r3 = r1 |+| r2
-      * // val r3: com.github.tarao.record4s.%{val name: String; val age: Int} & com.github.tarao.record4s.%{val email: String} = %(name = tarao, age = 3, email = tarao@example.com)
-      *   }}}
-      *
-      * @tparam R2
-      *   a record type (given `RecordLike[R2]`)
-      * @param other
-      *   a record to concatenate
-      * @return
-      *   a new record which has the both fields from this record and `other`
-      */
-    inline def |+|[R2 <: %](other: R2)(using RecordLike[R2]): R & R2 =
-      ${ Macros.concatDirectlyImpl('record, 'other) }
-
     /** Give a type tag to this record.
       *
       * @example

--- a/src/main/scala/com/github/tarao/record4s/Record.scala
+++ b/src/main/scala/com/github/tarao/record4s/Record.scala
@@ -10,7 +10,7 @@ trait Record
 object Record {
 
   /** An empty record. */
-  val empty: % = new MapRecord(Map.empty)
+  val empty = newMapRecord[%](Map.empty)
 
   /** Get the field value of specified label.
     *
@@ -59,8 +59,10 @@ object Record {
     * @return
     *   a record
     */
-  transparent inline def from[T](x: T)(using RecordLike[T]) =
-    empty ++ x
+  inline def from[T, RR <: %](x: T)(using
+    RecordLike[T],
+    Typing.Aux[T, RR],
+  ): RR = empty ++ x
 
   extension [R <: %](record: R) {
 
@@ -100,8 +102,12 @@ object Record {
       * @return
       *   a new record which has the both fields from this record and `other`
       */
-    transparent inline def ++[R2](other: R2)(using RecordLike[R2]) =
-      ${ Macros.concatImpl('record, 'other) }
+    inline def ++[R2: RecordLike, RR <: %](
+      other: R2,
+    )(using Typing.Concat.Aux[R, R2, RR]): RR =
+      newMapRecord[RR](
+        record.__data ++ summon[RecordLike[R2]].tidiedIterableOf(other),
+      )
 
     /** Give a type tag to this record.
       *
@@ -141,8 +147,8 @@ object Record {
       * @return
       *   a record containing only fields in the target type
       */
-    inline def as[R2 >: R]: R2 =
-      ${ Macros.upcastImpl[R, R2]('record) }
+    inline def as[R2 >: R <: `%`: RecordLike]: R2 =
+      newMapRecord[R2](summon[RecordLike[R2]].tidiedIterableOf(record))
 
     /** Convert this record to a `Product`.
       *
@@ -175,11 +181,15 @@ object Record {
 
   given canEqualReflexive[R <: %]: CanEqual[R, R] = CanEqual.derived
 
-  given recordLike[R <: %]: RecordLike[R] with {
-    type FieldTypes = R
-
+  class RecordLikeRecord[R <: %] extends RecordLike[R] {
     def iterableOf(r: R): Iterable[(String, Any)] = r.__data
   }
+
+  transparent inline given recordLike[R <: %]: RecordLike[R] =
+    ${ Macros.derivedRecordLikeImpl }
+
+  private def newMapRecord[R <: %](record: Iterable[(String, Any)]): R =
+    new MapRecord(record.toMap).asInstanceOf[R]
 }
 
 /** Base class for records.

--- a/src/main/scala/com/github/tarao/record4s/RecordLike.scala
+++ b/src/main/scala/com/github/tarao/record4s/RecordLike.scala
@@ -1,20 +1,37 @@
 package com.github.tarao.record4s
 
+import scala.compiletime.{erasedValue, summonInline}
 import scala.deriving.Mirror
 
 trait RecordLike[R] {
   type FieldTypes
+  type ElemLabels <: Tuple
 
   def iterableOf(r: R): Iterable[(String, Any)]
+
+  inline def tidiedIterableOf(r: R): Iterable[(String, Any)] = {
+    val labels = RecordLike.setOfLabels[ElemLabels]
+    iterableOf(r).filter { case (label, _) => labels.contains(label) }
+  }
 }
 
 object RecordLike {
+  private inline def setOfLabels[T <: Tuple]: Set[String] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Set.empty
+      case _: (t *: ts) =>
+        val stringOf = summonInline[t <:< String]
+        val value = valueOf[t]
+        setOfLabels[ts] + stringOf(value)
+    }
+
   trait RecordLikeProductMirror[
     P <: Product,
-    ElemLabels <: Tuple,
-    ElemTypes <: Tuple,
+    ElemLabels0 <: Tuple,
+    FieldTypes0 <: Tuple,
   ] extends RecordLike[P] {
-    type FieldTypes = Tuple.Zip[ElemLabels, ElemTypes]
+    type FieldTypes = Tuple.Zip[ElemLabels0, FieldTypes0]
+    type ElemLabels = ElemLabels0
   }
 
   given ofProduct[P <: Product](using

--- a/src/main/scala/com/github/tarao/record4s/Typing.scala
+++ b/src/main/scala/com/github/tarao/record4s/Typing.scala
@@ -1,0 +1,16 @@
+package com.github.tarao.record4s
+
+private[record4s] object Typing {
+  type Aux[R, Out0 <: %] = Concat[%, R] { type Out = Out0 }
+
+  final class Concat[R1, R2] {
+    type Out <: %
+  }
+
+  object Concat {
+    type Aux[R1, R2, Out0 <: %] = Concat[R1, R2] { type Out = Out0 }
+
+    transparent inline given [R1: RecordLike, R2: RecordLike]: Concat[R1, R2] =
+      ${ Macros.derivedTypingConcatImpl }
+  }
+}

--- a/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
+++ b/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
@@ -168,36 +168,16 @@ class RecordSpec extends helper.UnitSpec {
                                                |}""".stripMargin
       }
 
-      it(
-        "should be combined refinement type of directly concatenated records",
-      ) {
-        val r1 = %(name = "tarao")
-        val r2 = %(age = 3, email = "tarao@example.com")
-        helper.showTypeOf(r1 |+| r2) shouldBe """% {
-                                                |  val name: String
-                                                |} & % {
-                                                |  val age: Int
-                                                |  val email: String
-                                                |}""".stripMargin
-        val r3 = r1 |+| r2
-        helper.showTypeOf(r3) shouldBe """% {
-                                         |  val name: String
-                                         |} & % {
-                                         |  val age: Int
-                                         |  val email: String
-                                         |}""".stripMargin
-      }
-
       it("should have flattened field types after ++ or +") {
         val r1 = %(name = "tarao")
         val r2 = %(age = 3)
         val r3 = %(email = "tarao@example.com")
-        helper.showTypeOf((r1 |+| r2) ++ r3) shouldBe """% {
-                                                        |  val name: String
-                                                        |  val age: Int
-                                                        |  val email: String
-                                                        |}""".stripMargin
-        val r4 = (r1 |+| r2) + (email = "tarao@example.com")
+        helper.showTypeOf((r1 ++ r2) ++ r3) shouldBe """% {
+                                                       |  val name: String
+                                                       |  val age: Int
+                                                       |  val email: String
+                                                       |}""".stripMargin
+        val r4 = (r1 ++ r2) + (email = "tarao@example.com")
         helper.showTypeOf(r4) shouldBe """% {
                                          |  val name: String
                                          |  val age: Int
@@ -264,53 +244,6 @@ class RecordSpec extends helper.UnitSpec {
         r3.name shouldBe "ikura"
         r3.age shouldBe 3
         "r3.email" shouldNot compile
-      }
-    }
-
-    describe("|+|") {
-      it("should allow concatenation two disjoint records") {
-        val r1 = %(name = "tarao", age = 3)
-        val r2 = %(email = "tarao@example.com")
-        val r3 = r1 |+| r2
-        r3.name shouldBe "tarao"
-        r3.age shouldBe 3
-        r3.email shouldBe "tarao@example.com"
-
-        val r4 = %(occupation = "engineer")
-        val r5 = r1 |+| r4
-        r5.name shouldBe "tarao"
-        r5.age shouldBe 3
-        r5.occupation shouldBe "engineer"
-      }
-
-      it("should reject duplicated fields") {
-        val r1 = %(name = "tarao", age = 3)
-        val r2 = %(name = "ikura", email = "ikura@example.com")
-        "r1 |+| r2" shouldNot compile
-      }
-
-      it("should not break other operations") {
-        val r1 = %(name = "tarao") |+| %(age = 3)
-        val r2 = %(email = "tarao@example.com")
-        val r3 = r1 ++ r2
-        r3.name shouldBe "tarao"
-        r3.age shouldBe 3
-        r3.email shouldBe "tarao@example.com"
-
-        val r4 = r1 + (email = "tarao@example.com")
-        r4.name shouldBe "tarao"
-        r4.age shouldBe 3
-        r4.email shouldBe "tarao@example.com"
-      }
-
-      it("should not affected by type-hidden values") {
-        val r1 = %(name = "tarao", age = 3)
-        val r2: % { val email: String } =
-          %(name = "ikura", age = 1, email = "ikura@example.com")
-        val r3 = r1 |+| r2
-        r3.name shouldBe "tarao"
-        r3.age shouldBe 3
-        r3.email shouldBe "ikura@example.com"
       }
     }
 
@@ -571,8 +504,6 @@ class RecordSpec extends helper.UnitSpec {
         val r3 = %(name = "ikura", age = 1)
         val r4 = %(name = "tarao", age = 3, email = "tarao@example.com")
         val r5: % { val name: String; val age: Int } = r4
-        val r6 = %(age = 3) |+| %(name = "tarao")
-        val r7 = r1 ++ r6
 
         (r1 == r1) shouldBe true
         (r1 == r2) shouldBe true
@@ -585,10 +516,6 @@ class RecordSpec extends helper.UnitSpec {
         (r5 == r1) shouldBe false
         (r1 == r5.as) shouldBe true
         (r5.as == r1) shouldBe true
-        (r1 == r6) shouldBe true
-        (r6 == r1) shouldBe true
-        (r1 == r7) shouldBe true
-        (r7 == r1) shouldBe true
       }
 
       it("should statically reject equality test of different types") {


### PR DESCRIPTION
- Resolve the return type of concatenation by a given `Typing.Concat` instance
  - This is required for both `|+|` and `++`
  - Otherwise, there can be an unsafe concatenation, e.g.
    ```scala
    def addEmail[R <: %](record: R, email: String): R & %{ val email: String } =
      record |+| %(email = email)
    ```
  - Derivation of `Typing.Concat` is `transparent inline given`
- Drop `|+|` since there is no advantage any more
  - To avoid the above example, we have two choices:
    - (1) reject such case
    - (2) take `using RecordLike[R], Typing.Concat.Aux[R, %{ val email: String }, RR], NoDuplicateField[RR]` params in the method to make it safe
  - If we take (1), `|+|` becomes less convenient than `++`
  - If we take (2), `|+|` uses  `transparent inline given` instance
    - We no longer have the advantage that the return type `R & R2` was very simple
