### PR TITLE
Provide a record type that behaves as a product type

### DIFF
--- a/src/main/scala/com/github/tarao/record4s/ProductProxy.scala
+++ b/src/main/scala/com/github/tarao/record4s/ProductProxy.scala
@@ -1,0 +1,62 @@
+package com.github.tarao.record4s
+
+import scala.deriving.Mirror
+
+final class ProductProxy(private val fields: (String, Any)*)
+    extends %
+    with Product {
+  override private[record4s] lazy val __data: Map[String, Any] = fields.toMap
+
+  override def productArity: Int = fields.size
+
+  override def productElement(n: Int): Any = fields(n)._2
+
+  override def productElementName(n: Int): String = fields(n)._1
+
+  override def canEqual(that: Any): Boolean = that.isInstanceOf[ProductProxy]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: ProductProxy => fields == that.fields
+      case _                  => false
+    }
+}
+
+object ProductProxy {
+  final class ProductProxyMirror[
+    P <: ProductProxy,
+    ElemTypes,
+    ElemLabels <: Tuple,
+  ](elemLabels: Seq[String])
+      extends Mirror.Product {
+    type MirroredMonoType = P
+    type MirroredType = P
+    type MirroredLabel = "ProductProxy"
+    type MirroredElemTypes = ElemTypes
+    type MirroredElemLabels = ElemLabels
+
+    def fromProduct(p: scala.Product): P =
+      new ProductProxy(elemLabels.zip(p.productIterator): _*).asInstanceOf[P]
+  }
+
+  inline given [P <: ProductProxy](using
+    r: RecordLike[P],
+  ): ProductProxyMirror[P, r.ElemTypes, r.ElemLabels] =
+    new ProductProxyMirror(r.elemLabels)
+
+  final class OfRecord[R <: %] {
+    type Out <: ProductProxy
+  }
+
+  object OfRecord {
+    transparent inline given [R <: %]: OfRecord[R] =
+      ${ Macros.derivedProductProxyOfRecordImpl }
+  }
+
+  inline def from[R <: %](
+    record: R,
+  )(using typer: OfRecord[R], r: RecordLike[R]): typer.Out =
+    new ProductProxy(r.elemLabels.map { label =>
+      (label, record.__data(label))
+    }: _*).asInstanceOf[typer.Out]
+}

--- a/src/main/scala/com/github/tarao/record4s/RecordLike.scala
+++ b/src/main/scala/com/github/tarao/record4s/RecordLike.scala
@@ -28,7 +28,7 @@ object RecordLike {
         stringOf(value) +: seqOfLabels[ts]
     }
 
-  final class RecordLikeProductMirror[
+  final class ProductMirrorRecordLike[
     P <: Product,
     ElemLabels0 <: Tuple,
     ElemTypes0 <: Tuple,
@@ -43,8 +43,8 @@ object RecordLike {
 
   given ofProduct[P <: Product](using
     m: Mirror.Of[P],
-  ): RecordLikeProductMirror[P, m.MirroredElemLabels, m.MirroredElemTypes] =
-    new RecordLikeProductMirror
+  ): ProductMirrorRecordLike[P, m.MirroredElemLabels, m.MirroredElemTypes] =
+    new ProductMirrorRecordLike
 
   type LabelsOf[T <: Tuple] <: Tuple = T match {
     case (l, _) *: tail => l *: LabelsOf[tail]

--- a/src/test/scala/com/github/tarao/record4s/ProductProxySpec.scala
+++ b/src/test/scala/com/github/tarao/record4s/ProductProxySpec.scala
@@ -1,0 +1,88 @@
+package com.github.tarao.record4s
+
+class ProductProxySpec extends helper.UnitSpec {
+  describe("ProductProxy") {
+    it("can be constructed from a record") {
+      val r1 = %(name = "tarao", age = 3)
+      val p1 = ProductProxy.from(r1)
+
+      p1 shouldBe a[%]
+      p1 shouldBe a[Product]
+      p1.productElement(0) shouldBe "tarao"
+      p1.productElement(1) shouldBe 3
+
+      p1.name shouldBe "tarao"
+      p1.age shouldBe 3
+
+      helper.showTypeOf(p1) shouldBe """ProductProxy {
+                                       |  val name: String
+                                       |  val age: Int
+                                       |}""".stripMargin
+
+      trait Person
+      val r2 = %(name = "tarao", age = 3).tag[Person]
+      val p2 = ProductProxy.from(r2)
+
+      p2 shouldBe a[%]
+      p2 shouldBe a[Tag[Person]]
+      p2 shouldBe a[Product]
+      p2.productElement(0) shouldBe "tarao"
+      p2.productElement(1) shouldBe 3
+
+      p2.name shouldBe "tarao"
+      p2.age shouldBe 3
+
+      helper.showTypeOf(p2) shouldBe """ProductProxy {
+                                       |  val name: String
+                                       |  val age: Int
+                                       |} & Tag[Person]""".stripMargin
+    }
+
+    it("can be mirrored") {
+      import scala.deriving.Mirror
+
+      type PersonRecord = ProductProxy {
+        val name: String
+        val age: Int
+      }
+
+      case class Person(name: String, age: Int)
+
+      val m1 = summon[Mirror.ProductOf[PersonRecord]]
+      summon[m1.MirroredMonoType =:= PersonRecord]
+      summon[m1.MirroredType =:= PersonRecord]
+      summon[m1.MirroredElemTypes =:= (String, Int)]
+      summon[m1.MirroredElemLabels =:= ("name", "age")]
+
+      val p1 = m1.fromProduct(("tarao", 3))
+      p1 shouldBe a[%]
+      p1 shouldBe a[Product]
+      p1.productElement(0) shouldBe "tarao"
+      p1.productElement(1) shouldBe 3
+
+      val p2 = m1.fromProduct(Person("tarao", 3))
+      p2 shouldBe a[%]
+      p2 shouldBe a[Product]
+      p2.productElement(0) shouldBe "tarao"
+      p2.productElement(1) shouldBe 3
+
+      val m2 = summon[Mirror.ProductOf[PersonRecord & Tag[Person]]]
+      summon[m2.MirroredMonoType =:= (PersonRecord & Tag[Person])]
+      summon[m2.MirroredType =:= (PersonRecord & Tag[Person])]
+      summon[m2.MirroredElemTypes =:= (String, Int)]
+      summon[m2.MirroredElemLabels =:= ("name", "age")]
+
+      val p3 = m2.fromProduct(("tarao", 3))
+      p3 shouldBe a[%]
+      p3 shouldBe a[Product]
+      p3.productElement(0) shouldBe "tarao"
+      p3.productElement(1) shouldBe 3
+
+      val p4 = m2.fromProduct(Person("tarao", 3))
+      p4 shouldBe a[%]
+      p4 shouldBe a[Product]
+      p4.productElement(0) shouldBe "tarao"
+      p4.productElement(1) shouldBe 3
+    }
+  }
+}


### PR DESCRIPTION
This enables us to easily derive encoder/decoder of records from that of products.  For example, encoder/decoder of [circe](https://github.com/circe/circe) can be defined as the folloing.

```scala
    import com.github.tarao.record4s.{%, ProductProxy}
    import io.circe.{Decoder, Encoder, HCursor, Json}

    inline given [R <: %](using
      pp: ProductProxy.OfRecord[R],
      enc: Encoder[pp.Out],
    ): Encoder[R] = new Encoder[R] {
      final def apply(r: R): Json = enc(ProductProxy.from(r))
    }

    inline given [R <: %](using
      pp: ProductProxy.OfRecord[R],
      upcast: pp.Out <:< R,
      dec: Decoder[pp.Out],
    ): Decoder[R] = new Decoder[R] {
      final def apply(c: HCursor): Decoder.Result[R] = dec(c).map(upcast(_))
    }
```

We could provide this officially but that's going to be after the first release of record4s.  We just prepare for it right now.
