### PR TITLE
Allow unnamed construction if all arguments are identifiers

### DIFF
--- a/modules/core/src/main/scala/com/github/tarao/record4s/ArrayRecord.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/ArrayRecord.scala
@@ -513,7 +513,7 @@ object ArrayRecord
     protected def record: ArrayRecord[R]
 
     transparent inline def applyDynamic(method: String)(
-      inline fields: (String, Any)*,
+      inline fields: Any*,
     ) =
       ${ ArrayRecordMacros.applyImpl('record, 'method, 'fields) }
 

--- a/modules/core/src/main/scala/com/github/tarao/record4s/ArrayRecordMacros.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/ArrayRecordMacros.scala
@@ -49,7 +49,7 @@ object ArrayRecordMacros {
   def applyImpl[R: Type](
     record: Expr[ArrayRecord[R]],
     method: Expr[String],
-    args: Expr[Seq[(String, Any)]],
+    args: Expr[Seq[Any]],
   )(using Quotes): Expr[Any] = withInternal {
     import internal.*
 

--- a/modules/core/src/main/scala/com/github/tarao/record4s/Macros.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/Macros.scala
@@ -31,7 +31,7 @@ object Macros {
   def applyImpl[R <: `%`: Type](
     record: Expr[R],
     method: Expr[String],
-    args: Expr[Seq[(String, Any)]],
+    args: Expr[Seq[Any]],
   )(using Quotes): Expr[Any] = withInternal {
     import internal.*
 

--- a/modules/core/src/main/scala/com/github/tarao/record4s/Record.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/Record.scala
@@ -334,7 +334,7 @@ object Record extends RecordPlatformSpecific {
 
   class Extensible[R <: %](private val record: R) extends AnyVal with Dynamic {
     transparent inline def applyDynamic(method: String)(
-      inline fields: (String, Any)*,
+      inline fields: Any*,
     ) =
       ${ Macros.applyImpl('record, 'method, 'fields) }
 

--- a/modules/core/src/test/scala/com/github/tarao/record4s/ArrayRecordSpec.scala
+++ b/modules/core/src/test/scala/com/github/tarao/record4s/ArrayRecordSpec.scala
@@ -39,6 +39,14 @@ class ArrayRecordSpec extends helper.UnitSpec {
         r3.age shouldBe 3
       }
 
+      it("can create records from identifiers") {
+        val name = "tarao"
+        val age = 3
+        val r = ArrayRecord(name, age)
+        r.name shouldBe "tarao"
+        r.age shouldBe 3
+      }
+
       it("can create records by adding fields") {
         val r1 = ArrayRecord(name = "tarao")
         r1.name shouldBe "tarao"
@@ -114,6 +122,13 @@ class ArrayRecordSpec extends helper.UnitSpec {
         """ArrayRecord("tarao")""" shouldNot typeCheck
 
         """ArrayRecord("tarao", age = 3)""" shouldNot typeCheck
+
+        val name = "tarao"
+        """ArrayRecord(name, age = 3)""" shouldNot typeCheck
+
+        case class Person(name: String)
+        val p = Person("tarao")
+        """ArrayRecord(p.name)""" shouldNot typeCheck
       }
     }
 

--- a/modules/core/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
+++ b/modules/core/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
@@ -37,6 +37,14 @@ class RecordSpec extends helper.UnitSpec {
         r3.age shouldBe 3
       }
 
+      it("can create records from identifiers") {
+        val name = "tarao"
+        val age = 3
+        val r = %(name, age)
+        r.name shouldBe "tarao"
+        r.age shouldBe 3
+      }
+
       it("can create records by adding fields") {
         val r1 = %(name = "tarao")
         r1.name shouldBe "tarao"
@@ -113,6 +121,13 @@ class RecordSpec extends helper.UnitSpec {
         """%("tarao")""" shouldNot typeCheck
 
         """%("tarao", age = 3)""" shouldNot typeCheck
+
+        val name = "tarao"
+        """%(name, age = 3)""" shouldNot typeCheck
+
+        case class Person(name: String)
+        val p = Person("tarao")
+        """%(p.name)""" shouldNot typeCheck
       }
     }
 


### PR DESCRIPTION
```scala
val name = "tarao"
val age = 3
val r = %(name, age)
// val r: com.github.tarao.record4s.%{val name: String; val age: Int} = %(name = tarao, age = 3)
```

----

Use `+` or `++` to mix with named construction.
```scala
val name = "tarao"
val r = %(name) + (age = 3)
// val r: com.github.tarao.record4s.%{val name: String; val age: Int} = %(name = tarao, age = 3)
```