### PR TITLE
Add upickle to publish list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,10 @@ target/
 .cache/
 .ipython/
 .jupyter/
+.metals
 .local/
+.js
+.native
+.bloop
+out
+.vscode

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val commonSettings = Def.settings(
 )
 
 lazy val root = tlCrossRootProject
-  .aggregate(core, circe)
+  .aggregate(core, circe, upickle)
   .settings(commonSettings)
   .settings(
     console        := (core.jvm / Compile / console).value,

--- a/modules/upickle/src/main/scala/com/github/tarao/record4s/upickle/ArrayRecord.scala
+++ b/modules/upickle/src/main/scala/com/github/tarao/record4s/upickle/ArrayRecord.scala
@@ -19,6 +19,7 @@ package record4s
 package upickle
 
 import _root_.upickle.default.{ReadWriter, readwriter}
+
 import upickle.Record.{readDict, writeDict}
 
 object ArrayRecord {


### PR DESCRIPTION
From what I can tell, the upickle module is currently unpublished. 

https://central.sonatype.com/search?q=record4s

I believe the reason to be, that the upickle project, is not added to the root build of the sbt-typlevel project. This teeny tiny PR, seeks to fix that.