### PR TITLE
More widely accept unnamed constructions

### DIFF
--- a/modules/core/src/main/scala/com/github/tarao/record4s/InternalMacros.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/InternalMacros.scala
@@ -417,12 +417,19 @@ private[record4s] class InternalMacros(using
     field: Expr[Any],
   ): (String, Expr[Any], Type[?]) = {
     def fieldTypeOf(
-      labelExpr: Expr[Any],
+      labelExpr: Expr[String],
       valueExpr: Expr[Any],
     ): (String, Expr[Any], Type[?]) = {
-      val label = labelExpr.asTerm match {
-        case Literal(StringConstant(label)) =>
+      val label = (labelExpr.value, valueExpr.asTerm) match {
+        case (Some(""), Ident(label)) =>
           validatedLabel(label, Some(labelExpr))
+
+        case (Some(""), Select(_, label)) =>
+          validatedLabel(label, Some(labelExpr))
+
+        case (Some(label), _) =>
+          validatedLabel(label, Some(labelExpr))
+
         case _ =>
           errorAndAbort(
             "Field label must be a literal string",
@@ -445,12 +452,7 @@ private[record4s] class InternalMacros(using
         fieldTypeOf(labelExpr, valueExpr)
 
       case expr =>
-        expr.asTerm match {
-          case Ident(name) =>
-            fieldTypeOf(Literal(StringConstant(name)).asExpr, expr)
-          case _ =>
-            errorAndAbort("Invalid field", Some(expr))
-        }
+        fieldTypeOf(Expr(""), expr)
     }
   }
 

--- a/modules/core/src/main/scala/com/github/tarao/record4s/InternalMacros.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/InternalMacros.scala
@@ -491,9 +491,8 @@ private[record4s] class InternalMacros(using
           }
       }
 
-    val namedFields = fieldTypes.map { case (label, value, _) =>
-      Expr.ofTuple((Literal(StringConstant(label)).asExprOf[String], value))
-    }
+    val namedFields =
+      fieldTypes.map((label, value, _) => Expr.ofTuple((Expr(label), value)))
     (Expr.ofSeq(namedFields), tupledFieldTypes)
   }
 

--- a/modules/core/src/test/scala/com/github/tarao/record4s/ArrayRecordSpec.scala
+++ b/modules/core/src/test/scala/com/github/tarao/record4s/ArrayRecordSpec.scala
@@ -42,9 +42,29 @@ class ArrayRecordSpec extends helper.UnitSpec {
       it("can create records from identifiers") {
         val name = "tarao"
         val age = 3
-        val r = ArrayRecord(name, age)
-        r.name shouldBe "tarao"
-        r.age shouldBe 3
+        val r1 = ArrayRecord(name, age)
+        r1.name shouldBe "tarao"
+        r1.age shouldBe 3
+
+        val r2 = ArrayRecord(name, age = 3)
+        r2.name shouldBe "tarao"
+        r2.age shouldBe 3
+
+        val r3 = ArrayRecord(name = "tarao", age)
+        r3.name shouldBe "tarao"
+        r3.age shouldBe 3
+
+        class A {
+          val name = "tarao"
+          def record = ArrayRecord(name)
+        }
+        val r4 = new A().record
+        r4.name shouldBe "tarao"
+
+        case class Person(name: String)
+        val p = Person("tarao")
+        val r5 = ArrayRecord(p.name)
+        r5.name shouldBe "tarao"
       }
 
       it("can create records by adding fields") {
@@ -122,13 +142,6 @@ class ArrayRecordSpec extends helper.UnitSpec {
         """ArrayRecord("tarao")""" shouldNot typeCheck
 
         """ArrayRecord("tarao", age = 3)""" shouldNot typeCheck
-
-        val name = "tarao"
-        """ArrayRecord(name, age = 3)""" shouldNot typeCheck
-
-        case class Person(name: String)
-        val p = Person("tarao")
-        """ArrayRecord(p.name)""" shouldNot typeCheck
       }
     }
 

--- a/modules/core/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
+++ b/modules/core/src/test/scala/com/github/tarao/record4s/RecordSpec.scala
@@ -40,9 +40,29 @@ class RecordSpec extends helper.UnitSpec {
       it("can create records from identifiers") {
         val name = "tarao"
         val age = 3
-        val r = %(name, age)
-        r.name shouldBe "tarao"
-        r.age shouldBe 3
+        val r1 = %(name, age)
+        r1.name shouldBe "tarao"
+        r1.age shouldBe 3
+
+        val r2 = %(name, age = 3)
+        r2.name shouldBe "tarao"
+        r2.age shouldBe 3
+
+        val r3 = %(name = "tarao", age)
+        r3.name shouldBe "tarao"
+        r3.age shouldBe 3
+
+        class A {
+          val name = "tarao"
+          def record = %(name)
+        }
+        val r4 = new A().record
+        r4.name shouldBe "tarao"
+
+        case class Person(name: String)
+        val p = Person("tarao")
+        val r5 = %(p.name)
+        r5.name shouldBe "tarao"
       }
 
       it("can create records by adding fields") {
@@ -121,13 +141,6 @@ class RecordSpec extends helper.UnitSpec {
         """%("tarao")""" shouldNot typeCheck
 
         """%("tarao", age = 3)""" shouldNot typeCheck
-
-        val name = "tarao"
-        """%(name, age = 3)""" shouldNot typeCheck
-
-        case class Person(name: String)
-        val p = Person("tarao")
-        """%(p.name)""" shouldNot typeCheck
       }
     }
 


### PR DESCRIPTION

```scala
val name = "tarao"
%(name, age = 3)
```

```scala
class A {
  val name = "tarao"
  def record = %(name)
}
```
