### PR TITLE
Provide pretty syntax for generic record typing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ProjectKeys._
 import Implicits._
 
-ThisBuild / tlBaseVersion := "0.11"
+ThisBuild / tlBaseVersion := "0.12"
 
 ThisBuild / projectName := "record4s"
 ThisBuild / groupId     := "com.github.tarao"

--- a/modules/core/src/main/scala/com/github/tarao/record4s/ArrayRecord.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/ArrayRecord.scala
@@ -462,8 +462,8 @@ object ArrayRecord
       withPotentialTypingError {
         withPotentialTypingError {
           record.shrinkTo[Tuple.Zip[rr.ElemLabels, rr.ElemTypes]]
-        } (using ev)
-      } (using r)
+        }(using ev)
+      }(using r)
 
     /** Convert this record to a `To`.
       *

--- a/modules/core/src/main/scala/com/github/tarao/record4s/ArrayRecord.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/ArrayRecord.scala
@@ -454,13 +454,16 @@ object ArrayRecord
       * @return
       *   a new record without the unselected fields
       */
-    inline def apply[U <: Tuple, RR <: %](u: Unselector[U])(using
-      ev: Unselect.Aux[R, U, RR],
+    inline def apply[U <: Tuple, R2 <: %, RR <: %](u: Unselector[U])(using
+      r: typing.Record.Aux[ArrayRecord[R], R2],
+      ev: Unselect.Aux[R2, U, RR],
       rr: RecordLike[RR],
     ): ArrayRecord[Tuple.Zip[rr.ElemLabels, rr.ElemTypes]] =
       withPotentialTypingError {
-        record.shrinkTo[Tuple.Zip[rr.ElemLabels, rr.ElemTypes]]
-      }
+        withPotentialTypingError {
+          record.shrinkTo[Tuple.Zip[rr.ElemLabels, rr.ElemTypes]]
+        } (using ev)
+      } (using r)
 
     /** Convert this record to a `To`.
       *

--- a/modules/core/src/main/scala/com/github/tarao/record4s/Macros.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/Macros.scala
@@ -184,7 +184,7 @@ object Macros {
     }
   }
 
-  def derivedTypingUnselectImpl[R: Type, U <: Tuple: Type](using
+  def derivedTypingUnselectImpl[R <: `%`: Type, U <: Tuple: Type](using
     Quotes,
   ): Expr[Unselect[R, U]] = withTyping {
     import internal.*

--- a/modules/core/src/main/scala/com/github/tarao/record4s/Record.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/Record.scala
@@ -211,10 +211,9 @@ object Record extends RecordPlatformSpecific {
       * @return
       *   a new record without the unselected fields
       */
-    inline def apply[U <: Tuple, RR <: %](u: Unselector[U])(using
+    inline def apply[U <: Tuple, RR >: R <: %](u: Unselector[U])(using
       Unselect.Aux[R, U, RR],
       RecordLike[RR],
-      R <:< RR,
     ): RR = withPotentialTypingError {
       newMapRecord[RR](summon[RecordLike[RR]].tidiedIterableOf(record))
     }

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/ArrayRecord.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/ArrayRecord.scala
@@ -38,14 +38,6 @@ object ArrayRecord {
       ${ ArrayRecordMacros.derivedTypingConcatImpl }
   }
 
-  type Append[R1, R2] = Concat[R1, R2]
-
-  object Append {
-    type Aux[R1, R2, Out0 <: ProductRecord] = Concat[R1, R2] {
-      type Out = Out0
-    }
-  }
-
   @implicitNotFound("Value '${Label}' is not a member of ${R}")
   final class Lookup[R, Label] private () {
     type Out

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/Record.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/Record.scala
@@ -62,16 +62,16 @@ object Record {
       ${ Macros.derivedTypingSelectImpl }
   }
 
-  final class Unselect[R, U] private extends MaybeError {
-    type Out <: %
+  final class Unselect[R <: %, U] private extends MaybeError {
+    type Out >: R <: %
   }
 
   object Unselect {
     private[record4s] val instance = new Unselect[Nothing, Nothing]
 
-    type Aux[R, U, Out0 <: %] = Unselect[R, U] { type Out = Out0 }
+    type Aux[R <: %, U, Out0 <: %] = Unselect[R, U] { type Out = Out0 }
 
-    transparent inline given [R: RecordLike, S <: Tuple]: Unselect[R, S] =
+    transparent inline given [R <: %, S <: Tuple]: Unselect[R, S] =
       ${ Macros.derivedTypingUnselectImpl }
   }
 }

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/Record.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/Record.scala
@@ -35,12 +35,6 @@ object Record {
       ${ Macros.derivedTypingConcatImpl }
   }
 
-  type Append[R1, R2] = Concat[R1, R2]
-
-  object Append {
-    type Aux[R1, R2, Out0 <: %] = Concat[R1, R2] { type Out = Out0 }
-  }
-
   @implicitNotFound("Value '${Label}' is not a member of ${R}")
   final class Lookup[R, Label] private () {
     type Out

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
@@ -41,7 +41,7 @@ object syntax {
 
   type -[R <: %, L] = Record.Unselect[R, L *: EmptyTuple]
 
-  type in[L, R] = R match {
+  infix type in[L, R] = R match {
     case %     => Record.Lookup[R, L]
     case Tuple => ArrayRecord.Lookup[R, L]
   }

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
@@ -37,9 +37,9 @@ object syntax {
     case _ => ArrayRecord.Concat[R, F *: EmptyTuple]
   }
 
-  type --[R, U <: Tuple] = Record.Unselect[R, U]
+  type --[R <: %, U <: Tuple] = Record.Unselect[R, U]
 
-  type -[R, L] = Record.Unselect[R, L *: EmptyTuple]
+  type -[R <: %, L] = Record.Unselect[R, L *: EmptyTuple]
 
   type in[L, R] = R match {
     case % => Record.Lookup[R, L]

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
@@ -20,6 +20,7 @@ package typing
 object syntax {
   type :=[Out0, A] = A match {
     case Record.Concat[r1, r2]      => Record.Concat.Aux[r1, r2, Out0]
+    case Record.Unselect[r, u]      => Record.Unselect.Aux[r, u, Out0]
     case Record.Lookup[r, l]        => Record.Lookup.Aux[r, l, Out0]
     case ArrayRecord.Concat[r1, r2] => ArrayRecord.Concat.Aux[r1, r2, Out0]
     case ArrayRecord.Lookup[r, l] =>
@@ -30,6 +31,8 @@ object syntax {
     case % => Record.Concat[R1, R2]
     case _ => ArrayRecord.Concat[R1, R2]
   }
+
+  type --[R, U <: Tuple] = Record.Unselect[R, U]
 
   type in[L, R] = R match {
     case % => Record.Lookup[R, L]

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 record4s authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.tarao.record4s
+package typing
+
+object syntax {
+  type :=[Out0, A] = A match {
+    case Record.Concat[r1, r2]      => Record.Concat.Aux[r1, r2, Out0]
+    case Record.Lookup[r, l]        => Record.Lookup.Aux[r, l, Out0]
+    case ArrayRecord.Concat[r1, r2] => ArrayRecord.Concat.Aux[r1, r2, Out0]
+    case ArrayRecord.Lookup[r, l] =>
+      ArrayRecord.Lookup[r, l] { type Out = Out0 }
+  }
+
+  type ++[R1, R2] = R1 match {
+    case % => Record.Concat[R1, R2]
+    case _ => ArrayRecord.Concat[R1, R2]
+  }
+
+  type in[L, R] = R match {
+    case % => Record.Lookup[R, L]
+    case _ => ArrayRecord.Lookup[R, L]
+  }
+
+  type by[L, I] = L match {
+    case o := (l in r) => ArrayRecord.Lookup.Aux[r, l, I, o]
+  }
+}

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
@@ -28,13 +28,13 @@ object syntax {
   }
 
   type ++[R1, R2] = R1 match {
-    case % => Record.Concat[R1, R2]
-    case _ => ArrayRecord.Concat[R1, R2]
+    case %     => Record.Concat[R1, R2]
+    case Tuple => ArrayRecord.Concat[R1, R2]
   }
 
   type +[R, F <: Tuple] = R match {
-    case % => Record.Concat[R, F *: EmptyTuple]
-    case _ => ArrayRecord.Concat[R, F *: EmptyTuple]
+    case %     => Record.Concat[R, F *: EmptyTuple]
+    case Tuple => ArrayRecord.Concat[R, F *: EmptyTuple]
   }
 
   type --[R <: %, U <: Tuple] = Record.Unselect[R, U]
@@ -42,8 +42,8 @@ object syntax {
   type -[R <: %, L] = Record.Unselect[R, L *: EmptyTuple]
 
   type in[L, R] = R match {
-    case % => Record.Lookup[R, L]
-    case _ => ArrayRecord.Lookup[R, L]
+    case %     => Record.Lookup[R, L]
+    case Tuple => ArrayRecord.Lookup[R, L]
   }
 
   type by[L, I] = L match {

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
@@ -24,7 +24,13 @@ object syntax {
     case Record.Lookup[r, l]        => Record.Lookup.Aux[r, l, Out0]
     case ArrayRecord.Concat[r1, r2] => ArrayRecord.Concat.Aux[r1, r2, Out0]
     case ArrayRecord.Lookup[r, l] =>
-      ArrayRecord.Lookup[r, l] { type Out = Out0 }
+      Out0 match {
+        case (o, i) =>
+          ArrayRecord.Lookup[r, l] {
+            type Out = o
+            type Index = i
+          }
+      }
   }
 
   type ++[R1, R2] = R1 match {
@@ -44,9 +50,5 @@ object syntax {
   infix type in[L, R] = R match {
     case %     => Record.Lookup[R, L]
     case Tuple => ArrayRecord.Lookup[R, L]
-  }
-
-  type by[L, I] = L match {
-    case o := (l in r) => ArrayRecord.Lookup.Aux[r, l, I, o]
   }
 }

--- a/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
+++ b/modules/core/src/main/scala/com/github/tarao/record4s/typing/syntax.scala
@@ -32,7 +32,14 @@ object syntax {
     case _ => ArrayRecord.Concat[R1, R2]
   }
 
+  type +[R, F <: Tuple] = R match {
+    case % => Record.Concat[R, F *: EmptyTuple]
+    case _ => ArrayRecord.Concat[R, F *: EmptyTuple]
+  }
+
   type --[R, U <: Tuple] = Record.Unselect[R, U]
+
+  type -[R, L] = Record.Unselect[R, L *: EmptyTuple]
 
   type in[L, R] = R match {
     case % => Record.Lookup[R, L]

--- a/modules/core/src/test/scala/external/UseCaseSpec.scala
+++ b/modules/core/src/test/scala/external/UseCaseSpec.scala
@@ -107,7 +107,7 @@ class UseCaseSpec extends helper.UnitSpec {
       r2.email shouldBe "tarao@example.com"
     }
 
-    it("should reject generic record concatenation without using Concat") {
+    it("should reject generic record concatenation without using ++ type") {
       """
       def addEmail[R <: %](record: R, email: String): Any =
         record ++ %(email = email)
@@ -206,7 +206,7 @@ class UseCaseSpec extends helper.UnitSpec {
       r2.email shouldBe "tarao@example.com"
     }
 
-    it("should reject generic record extension without using Append") {
+    it("should reject generic record extension without using ++ type") {
       """
       def addEmail[R <: %](record: R, email: String): Any =
         record + (email = email)
@@ -355,7 +355,7 @@ class UseCaseSpec extends helper.UnitSpec {
     import com.github.tarao.record4s.{%, ArrayRecord, ProductRecord, Tag}
     import com.github.tarao.record4s.typing.syntax.{++, :=}
 
-    it("can be done by using Append.Aux") {
+    it("can be done by using typing.syntax") {
       locally {
         def addEmail[R <: Tuple, RR <: ProductRecord](
           record: ArrayRecord[R],

--- a/modules/core/src/test/scala/external/UseCaseSpec.scala
+++ b/modules/core/src/test/scala/external/UseCaseSpec.scala
@@ -276,11 +276,11 @@ class UseCaseSpec extends helper.UnitSpec {
 
   describe("Generic array record lookup") {
     import com.github.tarao.record4s.ArrayRecord
-    import com.github.tarao.record4s.typing.syntax.{:=, by, in}
+    import com.github.tarao.record4s.typing.syntax.{:=, in}
 
     it("can be done by using Lookup") {
-      inline def getEmail[R, V, I <: Int](record: ArrayRecord[R])(using
-        V := ("email" in R) by I,
+      inline def getEmail[R <: Tuple, V, I <: Int](record: ArrayRecord[R])(using
+        (V, I) := ("email" in R),
       ): V = ArrayRecord.lookup(record, "email")
 
       val r0 = ArrayRecord(name = "tarao", age = 3)

--- a/modules/core/src/test/scala/external/UseCaseSpec.scala
+++ b/modules/core/src/test/scala/external/UseCaseSpec.scala
@@ -19,12 +19,12 @@ package external
 class UseCaseSpec extends helper.UnitSpec {
   describe("Generic record lookup") {
     import com.github.tarao.record4s.{%, Record}
-    import com.github.tarao.record4s.typing.Record.Lookup
+    import com.github.tarao.record4s.typing.syntax.{:=, in}
 
-    it("can be done by using Lookup") {
-      def getEmail[R <: %](record: R)(using
-        hasEmail: Lookup[R, "email"],
-      ): hasEmail.Out = Record.lookup(record, "email")
+    it("can be done by using typing.syntax") {
+      def getEmail[R <: %, V](record: R)(using
+        V := ("email" in R),
+      ): V = Record.lookup(record, "email")
 
       val r0 = %(name = "tarao", age = 3)
       val r1 = r0 + (email = "tarao@example.com")
@@ -35,26 +35,11 @@ class UseCaseSpec extends helper.UnitSpec {
 
   describe("Generic record extension with ++") {
     import com.github.tarao.record4s.{%, Tag}
-    import com.github.tarao.record4s.typing.Record.Concat
+    import com.github.tarao.record4s.typing.syntax.{++, :=}
 
-    it("can be done by using Concat") {
-      def addEmail[R <: %](record: R, email: String)(using
-        concat: Concat[R, % { val email: String }],
-      ): concat.Out = record ++ %(email = email)
-
-      val r0 = %(name = "tarao", age = 3)
-      val r1 = addEmail(r0, "tarao@example.com")
-      r1 shouldStaticallyBe a[
-        % { val name: String; val age: Int; val email: String },
-      ]
-      r1.name shouldBe "tarao"
-      r1.age shouldBe 3
-      r1.email shouldBe "tarao@example.com"
-    }
-
-    it("can be done by using Concat.Aux") {
+    it("can be done by using typing.syntax") {
       def addEmail[R <: %, RR <: %](record: R, email: String)(using
-        Concat.Aux[R, % { val email: String }, RR],
+        RR := R ++ % { val email: String },
       ): RR = record ++ %(email = email)
 
       val r0 = %(name = "tarao", age = 3)
@@ -69,7 +54,7 @@ class UseCaseSpec extends helper.UnitSpec {
 
     it("can replace existing field") {
       def addEmail[R <: %, T, RR <: %](record: R, email: T)(using
-        Concat.Aux[R, % { val email: T }, RR],
+        RR := R ++ % { val email: T },
       ): RR = record ++ %(email = email)
 
       val r0 = %(name = "tarao", age = 3, email = "tarao@example.com")
@@ -93,13 +78,13 @@ class UseCaseSpec extends helper.UnitSpec {
           def firstName: String = p.name.split(" ").head
 
           def withEmail[RR <: %](email: String)(using
-            Concat.Aux[R & Tag[Person], % { val email: String }, RR],
+            RR := (R & Tag[Person]) ++ % { val email: String },
           ): RR = p ++ %(email = email)
         }
       }
 
       def addEmail[R <: %, RR <: %](record: R, email: String)(using
-        Concat.Aux[R, % { val email: String }, RR],
+        RR := R ++ % { val email: String },
       ): RR = record ++ %(email = email)
 
       val r0 = %(name = "tarao fuguta", age = 3).tag[Person]
@@ -132,44 +117,12 @@ class UseCaseSpec extends helper.UnitSpec {
 
   describe("Generic record extension with +") {
     import com.github.tarao.record4s.{%, Tag}
-    import com.github.tarao.record4s.typing.Record.Append
+    import com.github.tarao.record4s.typing.syntax.{++, :=}
 
-    it("can be done by using Append") {
-      locally {
-        def addEmail[R <: %](record: R, email: String)(using
-          append: Append[R, % { val email: String }],
-        ): append.Out = record + (email = email)
-
-        val r0 = %(name = "tarao", age = 3)
-        val r1 = addEmail(r0, "tarao@example.com")
-        r1 shouldStaticallyBe a[
-          % { val name: String; val age: Int; val email: String },
-        ]
-        r1.name shouldBe "tarao"
-        r1.age shouldBe 3
-        r1.email shouldBe "tarao@example.com"
-      }
-
-      locally {
-        def addEmail[R <: %](record: R, email: String)(using
-          append: Append[R, ("email", String) *: EmptyTuple],
-        ): append.Out = record + (email = email)
-
-        val r0 = %(name = "tarao", age = 3)
-        val r1 = addEmail(r0, "tarao@example.com")
-        r1 shouldStaticallyBe a[
-          % { val name: String; val age: Int; val email: String },
-        ]
-        r1.name shouldBe "tarao"
-        r1.age shouldBe 3
-        r1.email shouldBe "tarao@example.com"
-      }
-    }
-
-    it("can be done by using Append.Aux") {
+    it("can be done by using typing.syntax") {
       locally {
         def addEmail[R <: %, RR <: %](record: R, email: String)(using
-          Append.Aux[R, % { val email: String }, RR],
+          RR := R ++ % { val email: String },
         ): RR = record + (email = email)
 
         val r0 = %(name = "tarao", age = 3)
@@ -184,7 +137,7 @@ class UseCaseSpec extends helper.UnitSpec {
 
       locally {
         def addEmail[R <: %, RR <: %](record: R, email: String)(using
-          Append.Aux[R, ("email", String) *: EmptyTuple, RR],
+          RR := R ++ ("email", String) *: EmptyTuple,
         ): RR = record + (email = email)
 
         val r0 = %(name = "tarao", age = 3)
@@ -200,7 +153,7 @@ class UseCaseSpec extends helper.UnitSpec {
 
     it("can replace existing field") {
       def addEmail[R <: %, T, RR <: %](record: R, email: T)(using
-        Append.Aux[R, % { val email: T }, RR],
+        RR := R ++ % { val email: T },
       ): RR = record + (email = email)
 
       val r0 = %(name = "tarao", age = 3, email = "tarao@example.com")
@@ -224,13 +177,13 @@ class UseCaseSpec extends helper.UnitSpec {
           def firstName: String = p.name.split(" ").head
 
           def withEmail[RR <: %](email: String)(using
-            Append.Aux[R & Tag[Person], % { val email: String }, RR],
+            RR := (R & Tag[Person]) ++ % { val email: String },
           ): RR = p + (email = email)
         }
       }
 
       def addEmail[R <: %, RR <: %](record: R, email: String)(using
-        Append.Aux[R, % { val email: String }, RR],
+        RR := R ++ % { val email: String },
       ): RR = record + (email = email)
 
       val r0 = %(name = "tarao fuguta", age = 3).tag[Person]
@@ -263,12 +216,12 @@ class UseCaseSpec extends helper.UnitSpec {
 
   describe("Generic array record lookup") {
     import com.github.tarao.record4s.ArrayRecord
-    import com.github.tarao.record4s.typing.ArrayRecord.Lookup
+    import com.github.tarao.record4s.typing.syntax.{:=, by, in}
 
     it("can be done by using Lookup") {
-      inline def getEmail[R](record: ArrayRecord[R])(using
-        hasEmail: Lookup[R, "email"],
-      ): hasEmail.Out = ArrayRecord.lookup(record, "email")
+      inline def getEmail[R, V, I <: Int](record: ArrayRecord[R])(using
+        V := ("email" in R) by I,
+      ): V = ArrayRecord.lookup(record, "email")
 
       val r0 = ArrayRecord(name = "tarao", age = 3)
       val r1 = r0 + (email = "tarao@example.com")
@@ -279,30 +232,14 @@ class UseCaseSpec extends helper.UnitSpec {
 
   describe("Generic array record extension with ++") {
     import com.github.tarao.record4s.{ArrayRecord, ProductRecord, Tag}
-    import com.github.tarao.record4s.typing.ArrayRecord.Concat
+    import com.github.tarao.record4s.typing.syntax.{++, :=}
 
-    it("can be done by using Concat") {
-      def addEmail[R](record: ArrayRecord[R], email: String)(using
-        concat: Concat[R, ArrayRecord[("email", String) *: EmptyTuple]],
-      ): concat.Out = record ++ ArrayRecord(email = email)
-
-      val r0 = ArrayRecord(name = "tarao", age = 3)
-      val r1 = addEmail(r0, "tarao@example.com")
-      r1 shouldStaticallyBe an[ArrayRecord[
-        (("name", String), ("age", Int), ("email", String)),
-      ]]
-      r1.name shouldBe "tarao"
-      r1.age shouldBe 3
-      r1.email shouldBe "tarao@example.com"
-    }
-
-    it("can be done by using Concat.Aux") {
-      def addEmail[R, RR <: ProductRecord](
+    it("can be done by using typing.syntax") {
+      def addEmail[R <: Tuple, RR <: ProductRecord](
         record: ArrayRecord[R],
         email: String,
-      )(using
-        Concat.Aux[R, ArrayRecord[("email", String) *: EmptyTuple], RR],
-      ): RR = record ++ ArrayRecord(email = email)
+      )(using RR := R ++ ArrayRecord[("email", String) *: EmptyTuple]): RR =
+        record ++ ArrayRecord(email = email)
 
       val r0 = ArrayRecord(name = "tarao", age = 3)
       val r1 = addEmail(r0, "tarao@example.com")
@@ -316,12 +253,11 @@ class UseCaseSpec extends helper.UnitSpec {
 
     it("can replace existing field") {
       locally {
-        def addEmail[R, T, RR <: ProductRecord](
+        def addEmail[R <: Tuple, T, RR <: ProductRecord](
           record: ArrayRecord[R],
           email: T,
-        )(using
-          Concat.Aux[R, ArrayRecord[("email", T) *: EmptyTuple], RR],
-        ): RR = record ++ ArrayRecord(email = email)
+        )(using RR := R ++ ArrayRecord[("email", T) *: EmptyTuple]): RR =
+          record ++ ArrayRecord(email = email)
 
         val r0 =
           ArrayRecord(name = "tarao", age = 3, email = "tarao@example.com")
@@ -341,8 +277,11 @@ class UseCaseSpec extends helper.UnitSpec {
       }
 
       locally {
-        def rename[R, T, RR <: ProductRecord](record: ArrayRecord[R], value: T)(
-          using Concat.Aux[R, ArrayRecord[("name", T) *: EmptyTuple], RR],
+        def rename[R <: Tuple, T, RR <: ProductRecord](
+          record: ArrayRecord[R],
+          value: T,
+        )(using
+          RR := R ++ ArrayRecord[("name", T) *: EmptyTuple],
         ): RR = record ++ ArrayRecord(name = value)
 
         val r0 =
@@ -371,17 +310,17 @@ class UseCaseSpec extends helper.UnitSpec {
           def firstName: String = p.name.split(" ").head
 
           def withEmail[RR <: ProductRecord](email: String)(using
-            Concat.Aux[
-              (("name", String) *: T) & Tag[Person],
+            RR := ((("name", String) *: T) & Tag[Person]) ++
               ArrayRecord[("email", String) *: EmptyTuple],
-              RR,
-            ],
           ): RR = p ++ ArrayRecord(email = email)
         }
       }
 
-      def addEmail[R, T, RR <: ProductRecord](record: ArrayRecord[R], email: T)(
-        using Concat.Aux[R, ArrayRecord[("email", T) *: EmptyTuple], RR],
+      def addEmail[R <: Tuple, T, RR <: ProductRecord](
+        record: ArrayRecord[R],
+        email: T,
+      )(using
+        RR := R ++ ArrayRecord[("email", T) *: EmptyTuple],
       ): RR = record ++ ArrayRecord(email = email)
 
       val r0 = ArrayRecord(name = "tarao fuguta", age = 3).tag[Person]
@@ -414,48 +353,15 @@ class UseCaseSpec extends helper.UnitSpec {
 
   describe("Generic array record extension with +") {
     import com.github.tarao.record4s.{%, ArrayRecord, ProductRecord, Tag}
-    import com.github.tarao.record4s.typing.ArrayRecord.Append
-
-    it("can be done by using Append") {
-      locally {
-        def addEmail[R](record: ArrayRecord[R], email: String)(using
-          append: Append[R, ("email", String) *: EmptyTuple],
-        ): append.Out = record + (email = email)
-
-        val r0 = ArrayRecord(name = "tarao", age = 3)
-        val r1 = addEmail(r0, "tarao@example.com")
-        r1 shouldStaticallyBe a[ArrayRecord[
-          (("name", String), ("age", Int), ("email", String)),
-        ]]
-        r1.name shouldBe "tarao"
-        r1.age shouldBe 3
-        r1.email shouldBe "tarao@example.com"
-      }
-
-      locally {
-        def addEmail[R](record: ArrayRecord[R], email: String)(using
-          append: Append[R, % { val email: String }],
-        ): append.Out = record + (email = email)
-
-        val r0 = ArrayRecord(name = "tarao", age = 3)
-        val r1 = addEmail(r0, "tarao@example.com")
-        r1 shouldStaticallyBe a[ArrayRecord[
-          (("name", String), ("age", Int), ("email", String)),
-        ]]
-        r1.name shouldBe "tarao"
-        r1.age shouldBe 3
-        r1.email shouldBe "tarao@example.com"
-      }
-    }
+    import com.github.tarao.record4s.typing.syntax.{++, :=}
 
     it("can be done by using Append.Aux") {
       locally {
-        def addEmail[R, RR <: ProductRecord](
+        def addEmail[R <: Tuple, RR <: ProductRecord](
           record: ArrayRecord[R],
           email: String,
-        )(using
-          Append.Aux[R, ("email", String) *: EmptyTuple, RR],
-        ): RR = record + (email = email)
+        )(using RR := R ++ ("email", String) *: EmptyTuple): RR =
+          record + (email = email)
 
         val r0 = ArrayRecord(name = "tarao", age = 3)
         val r1 = addEmail(r0, "tarao@example.com")
@@ -468,12 +374,11 @@ class UseCaseSpec extends helper.UnitSpec {
       }
 
       locally {
-        def addEmail[R, RR <: ProductRecord](
+        def addEmail[R <: Tuple, RR <: ProductRecord](
           record: ArrayRecord[R],
           email: String,
-        )(using
-          Append.Aux[R, % { val email: String }, RR],
-        ): RR = record + (email = email)
+        )(using RR := R ++ % { val email: String }): RR =
+          record + (email = email)
 
         val r0 = ArrayRecord(name = "tarao", age = 3)
         val r1 = addEmail(r0, "tarao@example.com")
@@ -488,12 +393,11 @@ class UseCaseSpec extends helper.UnitSpec {
 
     it("can replace existing field") {
       locally {
-        def addEmail[R, T, RR <: ProductRecord](
+        def addEmail[R <: Tuple, T, RR <: ProductRecord](
           record: ArrayRecord[R],
           email: T,
-        )(using
-          Append.Aux[R, ("email", T) *: EmptyTuple, RR],
-        ): RR = record + (email = email)
+        )(using RR := R ++ ("email", T) *: EmptyTuple): RR =
+          record + (email = email)
 
         val r0 =
           ArrayRecord(name = "tarao", age = 3, email = "tarao@example.com")
@@ -513,8 +417,11 @@ class UseCaseSpec extends helper.UnitSpec {
       }
 
       locally {
-        def rename[R, T, RR <: ProductRecord](record: ArrayRecord[R], value: T)(
-          using Append.Aux[R, ("name", T) *: EmptyTuple, RR],
+        def rename[R <: Tuple, T, RR <: ProductRecord](
+          record: ArrayRecord[R],
+          value: T,
+        )(using
+          RR := R ++ ("name", T) *: EmptyTuple,
         ): RR = record + (name = value)
 
         val r0 =
@@ -543,17 +450,17 @@ class UseCaseSpec extends helper.UnitSpec {
           def firstName: String = p.name.split(" ").head
 
           def withEmail[RR <: ProductRecord](email: String)(using
-            Append.Aux[
-              (("name", String) *: T) & Tag[Person],
+            RR := ((("name", String) *: T) & Tag[Person]) ++
               ("email", String) *: EmptyTuple,
-              RR,
-            ],
           ): RR = p + (email = email)
         }
       }
 
-      def addEmail[R, T, RR <: ProductRecord](record: ArrayRecord[R], email: T)(
-        using Append.Aux[R, ("email", T) *: EmptyTuple, RR],
+      def addEmail[R <: Tuple, T, RR <: ProductRecord](
+        record: ArrayRecord[R],
+        email: T,
+      )(using
+        RR := R ++ ("email", T) *: EmptyTuple,
       ): RR = record + (email = email)
 
       val r0 = ArrayRecord(name = "tarao fuguta", age = 3).tag[Person]

--- a/modules/core/src/test/scala/external/UseCaseSpec.scala
+++ b/modules/core/src/test/scala/external/UseCaseSpec.scala
@@ -264,7 +264,8 @@ class UseCaseSpec extends helper.UnitSpec {
 
       trait Person
 
-      val r0 = %(name = "tarao", age = 3, email = "tarao@example.com").tag[Person]
+      val r0 =
+        %(name = "tarao", age = 3, email = "tarao@example.com").tag[Person]
       val r1 = withoutAge(r0)
       r1.name shouldBe "tarao"
       r1.email shouldBe "tarao@example.com"

--- a/modules/core/src/test/scala/external/UseCaseSpec.scala
+++ b/modules/core/src/test/scala/external/UseCaseSpec.scala
@@ -230,13 +230,12 @@ class UseCaseSpec extends helper.UnitSpec {
   }
 
   describe("Generic record upcast") {
-    import com.github.tarao.record4s.{%, RecordLike, Tag}
+    import com.github.tarao.record4s.{%, Tag}
     import com.github.tarao.record4s.typing.syntax.{-, --, :=}
 
     it("can be done by using --") {
-      def withoutAge[R <: %, RR <: %](record: R)(using
+      def withoutAge[R <: %, RR >: R <: %](record: R)(using
         RR := R -- "age" *: EmptyTuple,
-        R <:< RR,
       ): RR = record
 
       val r0 = %(name = "tarao", age = 3, email = "tarao@example.com")
@@ -247,9 +246,8 @@ class UseCaseSpec extends helper.UnitSpec {
     }
 
     it("can be done by using -") {
-      def withoutAge[R <: %, RR <: %](record: R)(using
+      def withoutAge[R <: %, RR >: R <: %](record: R)(using
         RR := R - "age",
-        R <:< RR,
       ): RR = record
 
       val r0 = %(name = "tarao", age = 3, email = "tarao@example.com")
@@ -260,9 +258,8 @@ class UseCaseSpec extends helper.UnitSpec {
     }
 
     it("preserves a tag") {
-      def withoutAge[R <: %, RR <: %](record: R)(using
+      def withoutAge[R <: %, RR >: R <: %](record: R)(using
         RR := R -- "age" *: EmptyTuple,
-        R <:< RR,
       ): RR = record
 
       trait Person

--- a/modules/core/src/test/scala/external/UseCaseSpec.scala
+++ b/modules/core/src/test/scala/external/UseCaseSpec.scala
@@ -214,6 +214,40 @@ class UseCaseSpec extends helper.UnitSpec {
     }
   }
 
+  describe("Generic record upcast") {
+    import com.github.tarao.record4s.{%, RecordLike, Tag}
+    import com.github.tarao.record4s.typing.syntax.{--, :=}
+
+    it("can be done by using --") {
+      def withoutAge[R <: %, RR <: %](record: R)(using
+        RR := R -- "age" *: EmptyTuple,
+        R <:< RR,
+      ): RR = record
+
+      val r0 = %(name = "tarao", age = 3, email = "tarao@example.com")
+      val r1 = withoutAge(r0)
+      r1.name shouldBe "tarao"
+      r1.email shouldBe "tarao@example.com"
+      "r1.age" shouldNot typeCheck
+    }
+
+    it("preserves a tag") {
+      def withoutAge[R <: %, RR <: %](record: R)(using
+        RR := R -- "age" *: EmptyTuple,
+        R <:< RR,
+      ): RR = record
+
+      trait Person
+
+      val r0 = %(name = "tarao", age = 3, email = "tarao@example.com").tag[Person]
+      val r1 = withoutAge(r0)
+      r1.name shouldBe "tarao"
+      r1.email shouldBe "tarao@example.com"
+      "r1.age" shouldNot typeCheck
+      r1 shouldStaticallyBe a[Tag[Person]]
+    }
+  }
+
   describe("Generic array record lookup") {
     import com.github.tarao.record4s.ArrayRecord
     import com.github.tarao.record4s.typing.syntax.{:=, by, in}


### PR DESCRIPTION
## Before

```scala
import com.github.tarao.record4s.%
import com.github.tarao.record4s.typing.Record.Concat

def addEmail[R <: %, RR <: %](record: R, email: String)(using
  Concat.Aux[R, % { val email: String }, RR],
): RR = record + email
```

## After

```scala
import com.github.tarao.record4s.%
import com.github.tarao.record4s.typing.syntax.{++, :=}

def addEmail[R <: %, RR <: %](record: R, email: String)(using
  RR := R ++ % { val email: String },
): RR = record + email
```

or

```scala
import com.github.tarao.record4s.%
import com.github.tarao.record4s.typing.syntax.{+, :=}

def addEmail[R <: %, RR <: %](record: R, email: String)(using
  RR := R + ("email", String),
): RR = record + email
```